### PR TITLE
Migrate examples to APIv2

### DIFF
--- a/python/requirements.lock
+++ b/python/requirements.lock
@@ -1,5 +1,5 @@
 requests==2.18.4
-Pillow==5.1.0
+Pillow==5.4.1
 ## The following requirements were added by pip freeze:
 certifi==2018.1.18
 chardet==3.0.4

--- a/python/restb/examples/basic.py
+++ b/python/restb/examples/basic.py
@@ -1,7 +1,7 @@
+import base64
+
 from restb.sdk import *
 from restb.sdk.api import service
-
-import base64
 
 
 def test_api(client_key):
@@ -14,7 +14,7 @@ def test_api(client_key):
 
     # 2. Determine which solution (API and model) to use
     model_id = 're_features_v3'  # from list of keys from __MODELS
-    endpoint = __MODELS[model_id]
+    endpoint = __ENDPOINT
     params['model_id'] = model_id
 
     # 3. Insert in your client_key

--- a/python/restb/examples/multipredict.py
+++ b/python/restb/examples/multipredict.py
@@ -1,0 +1,39 @@
+import base64
+
+from restb.sdk import *
+from restb.sdk.api import service
+
+
+def test_api(client_key):
+
+    # note the module variables as defined in restb/sdk/__init__.py
+    params = __PARAMS.copy()
+
+    # 1. Pick which API endpoint to use (US vs. EU)
+    url = __URL_US
+
+    # 2. Determine which solution (API and model) to use
+    model_id = ','.join(__MODELS)
+    endpoint = __ENDPOINT_MULTIPREDICT
+    params['model_id'] = model_id
+
+    # 3. Insert in your client_key
+    params['client_key'] = client_key
+
+    # 4a. Pick an image_url
+    image_url = 'https://demo.restb.ai/images/demo/demo-1.jpg'
+    params['image_url'] = image_url
+
+    # # 4b. -OR- add a base64 encoded payload (development only!)
+    # file = '/tmp/demo-1.jpg'
+    # with open(file, "rb") as image_file:
+    #     image_base64 = base64.urlsafe_b64encode(image_file.read())
+    #     params['image_base64'] = image_base64
+
+    # 5. Call the API
+    return service(url=url, endpoint=endpoint, params=params)
+
+
+def run(client_key):
+    response = test_api(client_key)
+    print(response.text)

--- a/python/restb/examples/rate_limiting_robust.py
+++ b/python/restb/examples/rate_limiting_robust.py
@@ -28,7 +28,7 @@ def test_api(client_key):
     queue = mp.Queue()
     image_id = 1
     for url in urls:
-        for model in __MODELS.keys():
+        for model in __MODELS:
             queue.put(dict(id=image_id, url=url, model=model))
         image_id += 1
     results = mp.Queue()
@@ -164,11 +164,11 @@ def image_process_thread(url, client_key, queue, results,
             params['client_key'] = client_key
             params['image_url'] = img_url
             params['model_id'] = model_id
-            endpoint = __MODELS[model_id]
+            endpoint = __ENDPOINT
             start_time = now_millis()
             resp = service(url=url, endpoint=endpoint, params=params)
             end_time = now_millis()
-            msg = '[{http}] <{limit}> thread [{thread}] {msg}'
+            msg = '[{http}] thread [{thread}] {msg}'
             vals = None
             if resp is not None:
                 vals = json.loads(resp.text)
@@ -177,7 +177,6 @@ def image_process_thread(url, client_key, queue, results,
                 total = end_time - start_time
                 print(msg.format(
                     http=resp.status_code,
-                    limit=resp.headers['X-RateLimit-Remaining-second'],
                     thread=mp.current_process().name,
                     msg='processed request in [' + str(total) + '] ms')
                 )
@@ -194,7 +193,6 @@ def image_process_thread(url, client_key, queue, results,
                 # handle over-rate limit retrying
                 print(msg.format(
                     http=resp.status_code,
-                    limit=resp.headers['X-RateLimit-Remaining-second'],
                     thread=mp.current_process().name,
                     msg='surpassed rate limit, trying again')
                 )

--- a/python/restb/examples/rate_limiting_simple.py
+++ b/python/restb/examples/rate_limiting_simple.py
@@ -27,7 +27,7 @@ def test_api(client_key):
     queue = mp.Queue()
     image_id = 1
     for url in urls:
-        for model in __MODELS.keys():
+        for model in __MODELS:
             queue.put(dict(id=image_id, url=url, model=model))
         image_id += 1
     results = mp.Queue()
@@ -95,11 +95,11 @@ def image_process_thread(url, client_key, queue, results,
             params['client_key'] = client_key
             params['image_url'] = img_url
             params['model_id'] = model_id
-            endpoint = __MODELS[model_id]
+            endpoint = __ENDPOINT
             start_time = now_millis()
             resp = service(url=url, endpoint=endpoint, params=params)
             end_time = now_millis()
-            msg = '[{http}] <{limit}> thread [{thread}] {msg}'
+            msg = '[{http}] thread [{thread}] {msg}'
             vals = None
             if resp is not None:
                 vals = json.loads(resp.text)
@@ -108,7 +108,6 @@ def image_process_thread(url, client_key, queue, results,
                 total = end_time - start_time
                 print(msg.format(
                     http=resp.status_code,
-                    limit=resp.headers['X-RateLimit-Remaining-second'],
                     thread=mp.current_process().name,
                     msg='processed request in [' + str(total) + '] ms')
                 )
@@ -125,7 +124,6 @@ def image_process_thread(url, client_key, queue, results,
                 # handle over-rate limit retrying
                 print(msg.format(
                     http=resp.status_code,
-                    limit=resp.headers['X-RateLimit-Remaining-second'],
                     thread=mp.current_process().name,
                     msg='surpassed rate limit, trying again')
                 )

--- a/python/restb/examples/run.py
+++ b/python/restb/examples/run.py
@@ -1,11 +1,13 @@
-from restb.examples import basic, rate_limiting_simple, rate_limiting_robust
+from restb.examples import basic, multipredict, rate_limiting_simple, rate_limiting_robust
 
 
 if __name__ == '__main__':
     client_key = 'YOUR_CLIENT_KEY_HERE'
     print('1. running basic example')
     basic.run(client_key)
-    print('2. running simple rate limiting example')
+    print('2. running multipredict example')
+    multipredict.run(client_key)
+    print('3. running simple rate limiting example')
     rate_limiting_simple.run(client_key)
-    print('3. running robust rate limiting example')
+    print('4. running robust rate limiting example')
     rate_limiting_robust.run(client_key)

--- a/python/restb/sdk/__init__.py
+++ b/python/restb/sdk/__init__.py
@@ -1,17 +1,17 @@
 __URL_EU = 'https://api-eu.restb.ai'
 __URL_US = 'https://api-us.restb.ai'
-__MODELS = {
-    'real_estate_global_v2': '/vision/v1/classify',
-    're_styles': '/vision/v1/classify',
-    're_features_v3': '/vision/v1/segmentation',
-    're_logo': '/vision/v1/segmentation',
-    're_appliances': '/vision/v1/segmentation',
-    're_privacy': '/vision/v1/segmentation',
-    're_moderation': '/vision/v1/segmentation',
-    're_cond_bathroom': '/vision/v1/classify',
-    're_cond_kitchen': '/vision/v1/classify',
-    'blurry': '/vision/v1/blurry'
-}
+__ENDPOINT = '/vision/v2/predict'
+__MODELS = [
+    'real_estate_global_v2',
+    're_styles',
+    're_features_v3',
+    're_logo',
+    're_appliances',
+    're_compliance',
+    're_cond_bathroom',
+    're_cond_kitchen',
+    'blurry'
+]
 __PARAMS = {
     'client_key': None,
     'model_id': None,
@@ -23,6 +23,7 @@ __PARAMS = {
 __all__ = [
     '__URL_EU',
     '__URL_US',
+    '__ENDPOINT',
     '__MODELS',
     '__PARAMS'
 ]

--- a/python/restb/sdk/__init__.py
+++ b/python/restb/sdk/__init__.py
@@ -1,6 +1,7 @@
 __URL_EU = 'https://api-eu.restb.ai'
 __URL_US = 'https://api-us.restb.ai'
 __ENDPOINT = '/vision/v2/predict'
+__ENDPOINT_MULTIPREDICT = '/vision/v2/multipredict'
 __MODELS = [
     'real_estate_global_v2',
     're_styles',
@@ -24,6 +25,7 @@ __all__ = [
     '__URL_EU',
     '__URL_US',
     '__ENDPOINT',
+    '__ENDPOINT_MULTIPREDICT',
     '__MODELS',
     '__PARAMS'
 ]

--- a/python/restb/sdk/api.py
+++ b/python/restb/sdk/api.py
@@ -31,6 +31,6 @@ def resize_image(image):
     factor = small / 600 if small > 600 else 1.0
     resize_dimensions = int(x / factor), int(y / factor)
 
-    # resize (using BICUBIC resampling/interpolation)
-    image = image.resize(resize_dimensions, resample=Image.BICUBIC)
+    # resize (using LANCZOS resampling/interpolation)
+    image = image.resize(resize_dimensions, resample=Image.LANCZOS)
     return image

--- a/python/restb/sdk/api.py
+++ b/python/restb/sdk/api.py
@@ -6,7 +6,8 @@ from PIL import Image
 def service(url, endpoint, params):
     if params['image_base64'] is not None:
         params.pop('image_url', None)
-        return requests.post(url=url+endpoint, params=dict(client_key=params['client_key']), data=params, allow_redirects=False, timeout=60)
+        query_params = dict(client_key=params['client_key'])  # client_key should always be passed as a query parameter
+        return requests.post(url=url+endpoint, params=query_params, data=params, allow_redirects=False, timeout=60)
     else:
         params.pop('image_base64', None)
         return requests.get(url=url+endpoint, params=params, allow_redirects=True, timeout=30)


### PR DESCRIPTION
This PR has refactored the examples in order to use APIv2. Also, the new `multipredict` endpoint has been added with a new example.